### PR TITLE
Add animated home flow and secure room join experience

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@radix-ui/react-switch": "^1.0.3",
         "class-variance-authority": "^0.7.0",
         "clsx": "^2.1.0",
+        "framer-motion": "^11.11.1",
         "lucide-react": "^0.367.0",
         "luxon": "^3.4.4",
         "next": "^14.2.21",
@@ -3458,6 +3459,33 @@
         "url": "https://github.com/sponsors/rawify"
       }
     },
+    "node_modules/framer-motion": {
+      "version": "11.18.2",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-11.18.2.tgz",
+      "integrity": "sha512-5F5Och7wrvtLVElIpclDT0CBzMVg3dL22B64aZwHtsIY8RB4mXICLrkajK4G9R+ieSAGcgrLeae2SeUTg2pr6w==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-dom": "^11.18.1",
+        "motion-utils": "^11.18.1",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -4639,6 +4667,21 @@
       "engines": {
         "node": ">=16 || 14 >=14.17"
       }
+    },
+    "node_modules/motion-dom": {
+      "version": "11.18.1",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-11.18.1.tgz",
+      "integrity": "sha512-g76KvA001z+atjfxczdRtw/RXOM3OMSdd1f4DL77qCTF/+avrRJiawSG4yDibEQ215sr9kpinSlX2pCTJ9zbhw==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-utils": "^11.18.1"
+      }
+    },
+    "node_modules/motion-utils": {
+      "version": "11.18.1",
+      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-11.18.1.tgz",
+      "integrity": "sha512-49Kt+HKjtbJKLtgO/LKj9Ld+6vw9BjH5d9sc40R/kVyH8GLAXgT42M2NnuPcJNuA3s9ZfZBUcwIgpmZWGEE+hA==",
+      "license": "MIT"
     },
     "node_modules/ms": {
       "version": "2.1.3",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@radix-ui/react-separator": "^1.0.3",
     "@radix-ui/react-slot": "^1.0.2",
     "@radix-ui/react-switch": "^1.0.3",
+    "framer-motion": "^11.11.1",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.0",
     "lucide-react": "^0.367.0",

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,3 +1,7 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+body {
+  @apply min-h-screen bg-slate-950 text-slate-50 antialiased;
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,14 +1,77 @@
 'use client';
 
+import { AnimatePresence, motion } from 'framer-motion';
+import { useState } from 'react';
+import HomeScreen from '@/components/home-screen';
 import MeetingDashboard from '@/components/meeting-dashboard';
+import RoomJoinForm from '@/components/room-join-form';
 import { StopwatchProvider } from '@/components/useStopwatch';
 
+type AppView = 'home' | 'join-room' | 'dashboard';
+
 export default function Home() {
+  const [view, setView] = useState<AppView>('home');
+  const [activeRoom, setActiveRoom] = useState<{
+    code: string;
+    name?: string;
+  } | null>(null);
+
+  const handleStartNewSession = () => {
+    setActiveRoom(null);
+    setView('dashboard');
+  };
+
+  const handleJoinSuccess = (details: { code: string; name?: string }) => {
+    setActiveRoom(details);
+    setView('dashboard');
+  };
+
+  const handleExitDashboard = () => {
+    setView('home');
+  };
+
   return (
-    <main className="relative">
-      <StopwatchProvider>
-        <MeetingDashboard />
-      </StopwatchProvider>
+    <main className="relative min-h-screen overflow-hidden bg-gradient-to-b from-slate-900 via-slate-950 to-slate-900">
+      <div className="pointer-events-none absolute inset-0 -z-10 opacity-60">
+        <div className="absolute left-1/2 top-10 h-72 w-[48rem] -translate-x-1/2 rounded-full bg-emerald-500/30 blur-3xl" />
+        <div className="absolute left-1/4 top-1/3 h-60 w-[36rem] -translate-x-1/2 rounded-full bg-sky-500/20 blur-3xl" />
+        <div className="absolute right-1/4 bottom-12 h-52 w-[32rem] translate-x-1/3 rounded-full bg-indigo-500/20 blur-3xl" />
+      </div>
+      <AnimatePresence mode="wait">
+        {view === 'home' && (
+          <motion.div key="home-view" className="relative z-10">
+            <HomeScreen
+              onStart={handleStartNewSession}
+              onJoinRoom={() => setView('join-room')}
+            />
+          </motion.div>
+        )}
+        {view === 'join-room' && (
+          <motion.div key="join-view" className="relative z-10">
+            <RoomJoinForm
+              onCancel={() => setView('home')}
+              onSuccess={handleJoinSuccess}
+            />
+          </motion.div>
+        )}
+        {view === 'dashboard' && (
+          <motion.div
+            key="dashboard-view"
+            initial={{ opacity: 0, y: 30 }}
+            animate={{ opacity: 1, y: 0 }}
+            exit={{ opacity: 0, y: -30 }}
+            transition={{ duration: 0.45, ease: 'easeOut' }}
+            className="relative z-10"
+          >
+            <StopwatchProvider>
+              <MeetingDashboard
+                onExit={handleExitDashboard}
+                roomDetails={activeRoom ?? undefined}
+              />
+            </StopwatchProvider>
+          </motion.div>
+        )}
+      </AnimatePresence>
     </main>
   );
 }

--- a/src/components/home-screen.tsx
+++ b/src/components/home-screen.tsx
@@ -1,0 +1,141 @@
+'use client';
+
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { motion } from 'framer-motion';
+import {
+  ArrowRight,
+  CalendarClock,
+  ShieldCheck,
+  UsersRound,
+} from 'lucide-react';
+
+const featureItems = [
+  {
+    title: 'Track meeting costs in real time',
+    description:
+      'Bring transparency to every conversation with live salary-based tracking.',
+    icon: CalendarClock,
+  },
+  {
+    title: 'Collaborate with your whole team',
+    description:
+      'Invite teammates, adjust salaries, and keep the numbers visible for everyone.',
+    icon: UsersRound,
+  },
+  {
+    title: 'Secure rooms when you need privacy',
+    description:
+      'Protect sensitive meetings with password-gated rooms and quick prompts.',
+    icon: ShieldCheck,
+  },
+];
+
+interface HomeScreenProps {
+  onStart: () => void;
+  onJoinRoom: () => void;
+}
+
+const containerVariants = {
+  hidden: { opacity: 0, y: 30 },
+  visible: {
+    opacity: 1,
+    y: 0,
+    transition: { staggerChildren: 0.15, duration: 0.6, ease: 'easeOut' },
+  },
+};
+
+const itemVariants = {
+  hidden: { opacity: 0, y: 20 },
+  visible: { opacity: 1, y: 0, transition: { duration: 0.5, ease: 'easeOut' } },
+};
+
+const HomeScreen = ({ onStart, onJoinRoom }: HomeScreenProps) => {
+  return (
+    <div className="flex min-h-screen flex-col justify-between">
+      <motion.section
+        initial={{ opacity: 0, y: 16 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.7, ease: 'easeOut' }}
+        className="mx-auto flex w-full max-w-5xl flex-col items-center gap-10 px-6 pt-28 text-center lg:pt-36"
+      >
+        <motion.div
+          initial={{ opacity: 0, y: 12 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.5, delay: 0.1 }}
+          className="inline-flex items-center gap-2 rounded-full bg-white/10 px-4 py-1 text-sm font-medium text-white backdrop-blur"
+        >
+          <span className="inline-flex h-2 w-2 rounded-full bg-emerald-400" />
+          Live meeting insight
+        </motion.div>
+        <motion.h1
+          className="text-balance text-4xl font-semibold tracking-tight text-white sm:text-5xl lg:text-6xl"
+          initial={{ opacity: 0, y: 20 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.8, ease: 'easeOut', delay: 0.1 }}
+        >
+          Understand the true cost of every meeting in seconds
+        </motion.h1>
+        <motion.p
+          className="max-w-2xl text-lg text-white/80"
+          initial={{ opacity: 0, y: 20 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.6, ease: 'easeOut', delay: 0.2 }}
+        >
+          Meeting Costs Calculator helps teams stay aligned, make fast decisions, and
+          keep budgets in check with beautiful, transparent dashboards.
+        </motion.p>
+        <motion.div
+          className="flex flex-col items-center gap-4 sm:flex-row"
+          initial={{ opacity: 0, scale: 0.95 }}
+          animate={{ opacity: 1, scale: 1 }}
+          transition={{ duration: 0.5, delay: 0.3, ease: 'easeOut' }}
+        >
+          <Button
+            size="lg"
+            className="group bg-white text-slate-900 hover:bg-white/90"
+            onClick={onStart}
+          >
+            Start a new session
+            <ArrowRight className="ml-2 h-4 w-4 transition-transform group-hover:translate-x-1" />
+          </Button>
+          <Button
+            size="lg"
+            variant="secondary"
+            className="bg-white/10 text-white hover:bg-white/20"
+            onClick={onJoinRoom}
+          >
+            Join an existing room
+          </Button>
+        </motion.div>
+      </motion.section>
+
+      <motion.section
+        variants={containerVariants}
+        initial="hidden"
+        animate="visible"
+        className="mx-auto grid w-full max-w-5xl grid-cols-1 gap-6 px-6 pb-24 md:grid-cols-2 lg:grid-cols-3"
+      >
+        {featureItems.map((item) => (
+          <motion.div key={item.title} variants={itemVariants}>
+            <Card className="group h-full border-white/10 bg-white/5 text-left text-white shadow-lg backdrop-blur">
+              <CardHeader className="flex flex-row items-center gap-3">
+                <div className="flex h-12 w-12 items-center justify-center rounded-full bg-emerald-400/10 text-emerald-300 transition-colors group-hover:bg-emerald-400/20">
+                  <item.icon className="h-6 w-6" />
+                </div>
+                <CardTitle className="text-lg font-semibold text-white">
+                  {item.title}
+                </CardTitle>
+              </CardHeader>
+              <CardContent className="text-white/70">
+                {item.description}
+              </CardContent>
+            </Card>
+          </motion.div>
+        ))}
+      </motion.section>
+    </div>
+  );
+};
+
+export default HomeScreen;

--- a/src/components/meeting-cost-counter.tsx
+++ b/src/components/meeting-cost-counter.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { motion } from 'framer-motion';
 import { User } from '@/interfaces/user';
 import { salaryPerSecond } from '@/lib/calcuate-salary';
 import { useEffect, useState } from 'react';
@@ -29,10 +30,20 @@ const MeetingCostCounter = ({ users }: { users: User[] }) => {
   }, [timeElapsed, totalPayRatePerSecond]);
 
   return (
-    <div className="text-4xl py-4 px-6 flex items-center">
-      <span className="align-middle">$</span>
-      <SlotCounter value={wastedAmount.toFixed(2)} />
-    </div>
+    <motion.div
+      initial={{ opacity: 0, y: 12 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.4, ease: 'easeOut' }}
+      className="flex flex-col gap-2 text-white"
+    >
+      <span className="text-sm uppercase tracking-[0.3em] text-white/60">
+        Total meeting cost
+      </span>
+      <div className="flex items-baseline text-4xl font-semibold">
+        <span className="mr-1">$</span>
+        <SlotCounter value={wastedAmount.toFixed(2)} />
+      </div>
+    </motion.div>
   );
 };
 

--- a/src/components/meeting-dashboard.tsx
+++ b/src/components/meeting-dashboard.tsx
@@ -2,8 +2,9 @@
 
 import type { User } from '@/interfaces/user';
 import type { Form } from '@/types/form';
-import { UserPlus } from 'lucide-react';
-import { useState } from 'react';
+import { AnimatePresence, motion } from 'framer-motion';
+import { ArrowLeft, Sparkles, UserPlus, Users } from 'lucide-react';
+import { useMemo, useState } from 'react';
 import MeetingCostCounter from './meeting-cost-counter';
 import { Stopwatch } from './stopwatch';
 import { Button } from './ui/button';
@@ -11,11 +12,32 @@ import UserInputCard from './user-cards/user-input-card';
 import UserViewCard from './user-cards/user-view-card';
 import { useStopwatch } from './useStopwatch';
 
-const MeetingDashboard = () => {
+const MotionButton = motion(Button);
+
+interface MeetingDashboardProps {
+  roomDetails?: {
+    code: string;
+    name?: string;
+  };
+  onExit?: () => void;
+}
+
+const MeetingDashboard = ({ roomDetails, onExit }: MeetingDashboardProps) => {
   const { pause, start, reset, isRunning, timeElapsed } = useStopwatch();
   const [users, setUsers] = useState<Array<User>>([]);
   const [forms, setForms] = useState<Form[]>([{ key: crypto.randomUUID() }]);
   const [hasMeetingStarted, setHasMeetingStarted] = useState<boolean>(false);
+
+  const activeRoomTitle = useMemo(() => {
+    if (!roomDetails?.name) {
+      return hasMeetingStarted
+        ? 'Your meeting is live'
+        : 'Prepare your next meeting';
+    }
+    return hasMeetingStarted
+      ? `${roomDetails.name} is live`
+      : `Getting ready for ${roomDetails.name}`;
+  }, [hasMeetingStarted, roomDetails]);
 
   const addUser = (user: User): void => {
     setUsers((prevUsers) => [user, ...prevUsers]);
@@ -59,69 +81,149 @@ const MeetingDashboard = () => {
       text = 'Resume';
     }
     return (
-      <Button
+      <MotionButton
         size={'lg'}
         variant={!hasMeetingStarted ? 'default' : 'destructive'}
         onClick={toggleEditMode}
+        whileHover={{ scale: 1.05 }}
+        whileTap={{ scale: 0.96 }}
       >
         {text}
-      </Button>
+      </MotionButton>
     );
   };
 
   return (
-    <div>
-      {(hasMeetingStarted || timeElapsed > 0) && (
-        <div>
-          <div className="absolute inset-x-0 flex justify-center mt-10">
-            <Stopwatch />
+    <div className="relative flex min-h-screen flex-col pb-32 text-white">
+      <motion.header
+        initial={{ opacity: 0, y: 20 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.6, ease: 'easeOut' }}
+        className="mx-auto w-full max-w-6xl px-6 pt-24"
+      >
+        <div className="relative overflow-hidden rounded-3xl border border-white/10 bg-white/5 p-8 shadow-2xl backdrop-blur">
+          <div className="pointer-events-none absolute inset-0 -z-10 bg-gradient-to-br from-white/10 via-transparent to-emerald-500/10" />
+          <div className="flex flex-col gap-6 md:flex-row md:items-center md:justify-between">
+            <div className="space-y-2">
+              <p className="flex items-center gap-2 text-sm font-medium uppercase tracking-[0.3em] text-white/60">
+                <Sparkles className="h-4 w-4" />
+                {roomDetails ? `Room ${roomDetails.code}` : 'New live session'}
+              </p>
+              <h2 className="text-3xl font-semibold text-white sm:text-4xl">
+                {activeRoomTitle}
+              </h2>
+              <p className="max-w-xl text-sm text-white/60">
+                Add everyone who joined your meeting and watch the live timer and cost
+                tracker respond instantly.
+              </p>
+            </div>
+            <div className="flex flex-col items-start gap-3 sm:flex-row sm:items-center">
+              <div className="flex items-center gap-2 rounded-full border border-white/10 bg-white/10 px-4 py-2 text-sm text-white/80">
+                <Users className="h-4 w-4" />
+                {users.length} attendee{users.length === 1 ? '' : 's'}
+              </div>
+              {onExit && (
+                <MotionButton
+                  variant="ghost"
+                  className="text-white hover:bg-white/10"
+                  onClick={onExit}
+                  whileHover={{ x: -2 }}
+                  whileTap={{ scale: 0.95 }}
+                >
+                  <ArrowLeft className="mr-2 h-4 w-4" /> Back home
+                </MotionButton>
+              )}
+            </div>
           </div>
-          <div className="absolute inset-x-0 top-1/3 flex justify-center">
-            <MeetingCostCounter users={users} />
+
+          <div className="mt-10 grid gap-6 md:grid-cols-2">
+            <motion.div
+              initial={{ opacity: 0, y: 20 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ duration: 0.5, ease: 'easeOut' }}
+              className="rounded-2xl border border-white/10 bg-black/20 p-6 backdrop-blur"
+            >
+              <Stopwatch />
+            </motion.div>
+            <motion.div
+              initial={{ opacity: 0, y: 20 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ duration: 0.5, delay: 0.1, ease: 'easeOut' }}
+              className="rounded-2xl border border-white/10 bg-black/20 p-6 backdrop-blur"
+            >
+              <MeetingCostCounter users={users} />
+            </motion.div>
           </div>
         </div>
-      )}
-      <div className="flex min-h-screen items-center align-middle flex-wrap space-x-5 p-6">
-        {forms.map((form) => (
-          <UserInputCard
-            key={form.key}
-            formKey={form.key}
-            addUser={addUser}
-            removeForm={removeForm}
-            user={form.user}
-          />
-        ))}
-        {users.map((user) => (
-          <div key={user.id}>
-            <UserViewCard user={user} editUser={editUser} />
-          </div>
-        ))}
-      </div>
-      <div className="fixed bottom-12 inset-x-0 space-x-6 flex justify-center">
-        {users.length > 0 && renderStopStartMeetingButton()}
-        {!hasMeetingStarted && (
-          <>
-            <Button
-              className={timeElapsed > 0 ? '' : 'hidden'}
-              variant={'destructive'}
-              size={'lg'}
-              onClick={reset}
-            >
-              Reset
-            </Button>
-            <Button
-              className={hasMeetingStarted ? 'hidden' : ''}
-              size={'lg'}
-              variant={'success'}
-              disabled={hasMeetingStarted}
-              onClick={() => addForm()}
-            >
-              <UserPlus className="mr-2 h-5 w-5" />
-              Add user
-            </Button>
-          </>
+      </motion.header>
+
+      <section className="mx-auto w-full max-w-6xl flex-1 px-6 py-12">
+        <motion.div
+          layout
+          className="grid gap-6 sm:grid-cols-2 xl:grid-cols-3"
+          transition={{ layout: { duration: 0.4, ease: 'easeInOut' } }}
+        >
+          <AnimatePresence initial={false}>
+            {forms.map((form) => (
+              <UserInputCard
+                key={form.key}
+                formKey={form.key}
+                addUser={addUser}
+                removeForm={removeForm}
+                user={form.user}
+              />
+            ))}
+          </AnimatePresence>
+          <AnimatePresence initial={false}>
+            {users.map((user) => (
+              <UserViewCard key={user.id} user={user} editUser={editUser} />
+            ))}
+          </AnimatePresence>
+        </motion.div>
+      </section>
+
+      <AnimatePresence>
+        {(users.length > 0 || !hasMeetingStarted) && (
+          <motion.div
+            key="controls"
+            initial={{ opacity: 0, y: 40 }}
+            animate={{ opacity: 1, y: 0 }}
+            exit={{ opacity: 0, y: 40 }}
+            transition={{ duration: 0.3 }}
+            className="fixed bottom-8 left-1/2 z-30 w-[calc(100%-3rem)] max-w-3xl -translate-x-1/2 rounded-full border border-white/10 bg-white/10 p-4 shadow-2xl backdrop-blur"
+          >
+            <div className="flex flex-wrap items-center justify-center gap-3">
+              {users.length > 0 && renderStopStartMeetingButton()}
+              {!hasMeetingStarted && (
+                <>
+                  {timeElapsed > 0 && (
+                    <MotionButton
+                      variant={'destructive'}
+                      size={'lg'}
+                      onClick={reset}
+                      whileHover={{ scale: 1.05 }}
+                      whileTap={{ scale: 0.96 }}
+                    >
+                      Reset
+                    </MotionButton>
+                  )}
+                  <MotionButton
+                    size={'lg'}
+                    variant={'success'}
+                    disabled={hasMeetingStarted}
+                    onClick={() => addForm()}
+                    whileHover={{ scale: 1.05 }}
+                    whileTap={{ scale: 0.96 }}
+                  >
+                    <UserPlus className="mr-2 h-5 w-5" />
+                    Add user
+                  </MotionButton>
+                </>
+              )}
+            </div>
+          </motion.div>
         )}
-      </div>
+      </AnimatePresence>
     </div>
   );
 };

--- a/src/components/room-join-form.tsx
+++ b/src/components/room-join-form.tsx
@@ -1,0 +1,220 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import { motion, AnimatePresence } from 'framer-motion';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Button } from '@/components/ui/button';
+import { joinRoom, type JoinRoomResult } from '@/lib/room-service';
+import { Loader2, Lock, LogIn, RotateCcw } from 'lucide-react';
+
+interface RoomJoinFormProps {
+  onCancel: () => void;
+  onSuccess: (details: { code: string; name?: string }) => void;
+}
+
+type FeedbackState =
+  | { type: 'error'; message: string }
+  | { type: 'info'; message: string }
+  | { type: 'success'; message: string };
+
+const feedbackVariants = {
+  initial: { opacity: 0, y: 8 },
+  animate: { opacity: 1, y: 0, transition: { duration: 0.3 } },
+  exit: { opacity: 0, y: -8, transition: { duration: 0.2 } },
+};
+
+const RoomJoinForm = ({ onCancel, onSuccess }: RoomJoinFormProps) => {
+  const [roomCode, setRoomCode] = useState('');
+  const [password, setPassword] = useState('');
+  const [requiresPassword, setRequiresPassword] = useState(false);
+  const [feedback, setFeedback] = useState<FeedbackState | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const timeoutRef = useRef<number>();
+
+  useEffect(() => {
+    return () => {
+      if (timeoutRef.current) {
+        window.clearTimeout(timeoutRef.current);
+      }
+    };
+  }, []);
+
+  const handleResult = (result: JoinRoomResult) => {
+    if (result.status === 'joined') {
+      setFeedback({
+        type: 'success',
+        message: `Welcome! You are in ${result.roomName ?? "the room"}.`,
+      });
+      timeoutRef.current = window.setTimeout(() => {
+        onSuccess({ code: result.roomCode, name: result.roomName });
+      }, 650);
+      return;
+    }
+
+    if (result.status === 'password_required') {
+      setRequiresPassword(true);
+      setFeedback({ type: 'info', message: result.message });
+      return;
+    }
+
+    if (result.status === 'invalid_password') {
+      setRequiresPassword(true);
+      setFeedback({ type: 'error', message: result.message });
+      return;
+    }
+
+    if (result.status === 'not_found') {
+      setFeedback({ type: 'error', message: result.message });
+    }
+  };
+
+  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setIsSubmitting(true);
+    setFeedback(null);
+
+    const result = await joinRoom(roomCode, requiresPassword ? password : undefined);
+    setIsSubmitting(false);
+    handleResult(result);
+  };
+
+  const resetForm = () => {
+    setRoomCode('');
+    setPassword('');
+    setRequiresPassword(false);
+    setFeedback(null);
+  };
+
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 30 }}
+      animate={{ opacity: 1, y: 0 }}
+      exit={{ opacity: 0, y: -20 }}
+      transition={{ duration: 0.4, ease: 'easeOut' }}
+      className="flex min-h-screen items-center justify-center px-6 pb-16 pt-24"
+    >
+      <Card className="w-full max-w-md border-white/20 bg-white/10 text-white shadow-2xl backdrop-blur">
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2 text-2xl">
+            <Lock className="h-6 w-6" /> Join a room
+          </CardTitle>
+          <CardDescription className="text-white/70">
+            Enter your room code to continue. We will let you know if a password is
+            required.
+          </CardDescription>
+        </CardHeader>
+        <form onSubmit={handleSubmit}>
+          <CardContent className="space-y-6">
+            <div className="space-y-2">
+              <Label htmlFor="room-code" className="text-white/80">
+                Room code
+              </Label>
+              <Input
+                id="room-code"
+                value={roomCode}
+                onChange={(event) => setRoomCode(event.target.value.toUpperCase())}
+                placeholder="e.g. ALPHA123"
+                className="border-white/20 bg-white/5 text-white placeholder:text-white/40"
+                autoFocus
+                required
+              />
+            </div>
+            <AnimatePresence initial={false}>
+              {requiresPassword && (
+                <motion.div
+                  key="password-field"
+                  initial={{ height: 0, opacity: 0 }}
+                  animate={{ height: 'auto', opacity: 1 }}
+                  exit={{ height: 0, opacity: 0 }}
+                  transition={{ duration: 0.3, ease: 'easeOut' }}
+                  className="overflow-hidden space-y-2"
+                >
+                  <Label htmlFor="room-password" className="text-white/80">
+                    Room password
+                  </Label>
+                  <Input
+                    id="room-password"
+                    type="password"
+                    value={password}
+                    onChange={(event) => setPassword(event.target.value)}
+                    placeholder="Enter the password"
+                    className="border-white/20 bg-white/5 text-white placeholder:text-white/40"
+                    required
+                  />
+                </motion.div>
+              )}
+            </AnimatePresence>
+
+            <AnimatePresence mode="wait">
+              {feedback && (
+                <motion.div
+                  key={feedback.message}
+                  variants={feedbackVariants}
+                  initial="initial"
+                  animate="animate"
+                  exit="exit"
+                  className={`rounded-md border px-3 py-2 text-sm ${
+                    feedback.type === 'error'
+                      ? 'border-red-500/40 bg-red-500/10 text-red-200'
+                      : feedback.type === 'success'
+                        ? 'border-emerald-500/40 bg-emerald-500/10 text-emerald-100'
+                        : 'border-sky-400/40 bg-sky-400/10 text-sky-100'
+                  }`}
+                >
+                  {feedback.message}
+                </motion.div>
+              )}
+            </AnimatePresence>
+          </CardContent>
+          <CardFooter className="flex flex-col gap-3 sm:flex-row sm:justify-between">
+            <Button
+              type="button"
+              variant="ghost"
+              className="text-white hover:bg-white/10"
+              onClick={onCancel}
+            >
+              Cancel
+            </Button>
+            <div className="flex w-full flex-col gap-3 sm:w-auto sm:flex-row">
+              <Button
+                type="button"
+                variant="secondary"
+                className="bg-white/10 text-white hover:bg-white/20"
+                onClick={resetForm}
+              >
+                <RotateCcw className="mr-2 h-4 w-4" /> Reset
+              </Button>
+              <Button
+                type="submit"
+                disabled={isSubmitting}
+                className="bg-emerald-400 text-slate-900 hover:bg-emerald-300"
+              >
+                {isSubmitting ? (
+                  <>
+                    <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                    Checking...
+                  </>
+                ) : (
+                  <>
+                    <LogIn className="mr-2 h-4 w-4" /> Join room
+                  </>
+                )}
+              </Button>
+            </div>
+          </CardFooter>
+        </form>
+      </Card>
+    </motion.div>
+  );
+};
+
+export default RoomJoinForm;

--- a/src/components/stopwatch.tsx
+++ b/src/components/stopwatch.tsx
@@ -1,13 +1,24 @@
 'use client';
 
+import { motion } from 'framer-motion';
 import { Duration } from 'luxon';
 import { useStopwatch } from './useStopwatch';
 
 export const Stopwatch = () => {
   const { timeElapsed } = useStopwatch();
   return (
-    <div className="items-center text-4xl font-bold">
-      {Duration.fromMillis(timeElapsed).toFormat('hh:mm:ss')}
-    </div>
+    <motion.div
+      initial={{ opacity: 0, y: 10 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.4, ease: 'easeOut' }}
+      className="flex flex-col gap-1 text-white"
+    >
+      <span className="text-sm uppercase tracking-[0.3em] text-white/60">
+        Elapsed time
+      </span>
+      <span className="text-4xl font-semibold tracking-widest text-white">
+        {Duration.fromMillis(timeElapsed).toFormat('hh:mm:ss')}
+      </span>
+    </motion.div>
   );
 };

--- a/src/components/user-cards/user-input-card.tsx
+++ b/src/components/user-cards/user-input-card.tsx
@@ -20,11 +20,20 @@ import {
 } from '@/components/ui/select';
 import { PaymentInterval } from '@/enums/PaymentInterval';
 import { createUser } from '@/factory/user-factory';
-import { X } from 'lucide-react';
-import { useState } from 'react';
-import { Switch } from '../ui/switch';
-import { Separator } from '../ui/separator';
 import { User } from '@/interfaces/user';
+import { Separator } from '@/components/ui/separator';
+import { Switch } from '@/components/ui/switch';
+import { motion } from 'framer-motion';
+import { X } from 'lucide-react';
+import { useMemo, useState } from 'react';
+
+const MotionButton = motion(Button);
+
+const cardVariants = {
+  initial: { opacity: 0, y: 24, scale: 0.96 },
+  animate: { opacity: 1, y: 0, scale: 1, transition: { duration: 0.35 } },
+  exit: { opacity: 0, y: -16, scale: 0.95, transition: { duration: 0.2 } },
+};
 
 const UserInputCard = ({
   formKey,
@@ -39,17 +48,30 @@ const UserInputCard = ({
 }) => {
   const [name, setName] = useState<string>(user?.name || '');
   const [variant, setVariant] = useState<PaymentInterval>(
-    user?.payVariant || PaymentInterval.MONTH
+    user?.payVariant || PaymentInterval.MONTH,
   );
   const [hoursWorkedPerWeek, setHoursWorkedPerWeek] = useState<string>(
-    user?.hoursWorkedPerWeek.toString() || '40'
+    user?.hoursWorkedPerWeek.toString() || '40',
   );
   const [amount, setAmount] = useState<string>(user?.amount.toString() || '');
   const [isPayHidden, setIsPayHidden] = useState<boolean>(
-    user?.isPayHidden || false
+    user?.isPayHidden || false,
   );
 
+  const isValid = useMemo(() => {
+    const numericAmount = Number(amount);
+    const numericHours = Number(hoursWorkedPerWeek);
+    return (
+      name.trim().length > 0 &&
+      !Number.isNaN(numericAmount) &&
+      numericAmount > 0 &&
+      !Number.isNaN(numericHours) &&
+      numericHours > 0
+    );
+  }, [amount, hoursWorkedPerWeek, name]);
+
   const handleAddUser = () => {
+    if (!isValid) return;
     const id = crypto.randomUUID();
     const newUser = createUser(
       id,
@@ -57,48 +79,62 @@ const UserInputCard = ({
       variant,
       Number(hoursWorkedPerWeek),
       Number(amount),
-      isPayHidden
+      isPayHidden,
     );
     addUser(newUser);
     removeForm(formKey);
   };
 
   return (
-    <Card className="w-[350px] my-5">
-      <div className="flex justify-around">
-        <CardHeader>
-          <CardTitle>Add meeting attender</CardTitle>
-        </CardHeader>
-        <Button
-          onClick={() => removeForm(formKey)}
-          className="shrink-0 mt-2 mr-2"
-          aria-label="Remove form"
-          variant={'ghost'}
-          size={'icon'}
-        >
-          <X className="h-4 w-4" />
-        </Button>
-      </div>
-      <CardContent>
-        <form>
-          <div className="grid w-full items-center gap-4">
-            <div className="flex flex-col space-y-1.5">
-              <Label htmlFor="name">Name</Label>
+    <motion.div
+      layout
+      variants={cardVariants}
+      initial="initial"
+      animate="animate"
+      exit="exit"
+      whileHover={{ translateY: -6 }}
+    >
+      <Card className="my-5 w-full border-white/10 bg-white/5 text-white shadow-xl backdrop-blur">
+        <div className="flex items-start justify-between">
+          <CardHeader className="space-y-1">
+            <CardTitle className="text-lg">Add meeting attender</CardTitle>
+            <p className="text-sm text-white/60">
+              Capture attendee details to keep your cost tracking accurate.
+            </p>
+          </CardHeader>
+          <Button
+            onClick={() => removeForm(formKey)}
+            className="mt-4 mr-4 shrink-0 text-white hover:bg-white/10"
+            aria-label="Remove form"
+            variant={'ghost'}
+            size={'icon'}
+          >
+            <X className="h-4 w-4" />
+          </Button>
+        </div>
+        <CardContent>
+          <form className="space-y-5">
+            <div className="space-y-2">
+              <Label htmlFor="name" className="text-white/80">
+                Name
+              </Label>
               <Input
                 id="name"
                 maxLength={100}
                 value={name}
                 onChange={(e) => setName(e.target.value)}
                 placeholder="Name of the attendee"
+                className="border-white/20 bg-white/10 text-white placeholder:text-white/40"
               />
             </div>
-            <Separator />
-            <div className="flex space-x-1.5">
-              <div>
+            <Separator className="border-white/10" />
+            <div className="flex flex-col gap-4 sm:flex-row">
+              <div className="flex-1 space-y-2">
                 <Label
-                  id="pay-iteration-label"
+                  id={`pay-iteration-label-${formKey}`}
                   htmlFor="payVariant"
                   aria-label="Pay iteration"
+                  className="text-white/80"
                 >
                   Pay iteration
                 </Label>
@@ -107,12 +143,12 @@ const UserInputCard = ({
                   defaultValue={variant}
                 >
                   <SelectTrigger
-                    className="w-[180px]"
-                    aria-labelledby="pay-iteration-label"
+                    className="w-full border-white/20 bg-white/10 text-white"
+                    aria-labelledby={`pay-iteration-label-${formKey}`}
                   >
                     <SelectValue placeholder="Select a variant" />
                   </SelectTrigger>
-                  <SelectContent>
+                  <SelectContent className="border-white/10 bg-slate-900/95 text-white backdrop-blur">
                     <SelectGroup>
                       {Object.values(PaymentInterval).map((payVariant) => (
                         <SelectItem key={payVariant} value={payVariant}>
@@ -123,56 +159,81 @@ const UserInputCard = ({
                   </SelectContent>
                 </Select>
               </div>
-              <div>
-                <Label htmlFor="payVariant">Pay amount</Label>
+              <div className="flex-1 space-y-2">
+                <Label htmlFor="amount" className="text-white/80">
+                  Pay amount
+                </Label>
                 <Input
                   type="number"
                   id="amount"
                   placeholder="e.g. 18"
                   value={amount}
                   onChange={(e) => setAmount(e.target.value)}
+                  className="border-white/20 bg-white/10 text-white placeholder:text-white/40"
                 />
               </div>
             </div>
-            <div className="flex space-x-5">
-              <div>
-                <Label htmlFor="hoursWorked">Hours worked per week</Label>
+            <div className="flex flex-col gap-4 sm:flex-row">
+              <div className="flex-1 space-y-2">
+                <Label htmlFor="hoursWorked" className="text-white/80">
+                  Hours worked per week
+                </Label>
                 <Input
                   id="hoursWorked"
                   type="number"
                   value={hoursWorkedPerWeek}
                   onChange={(e) => setHoursWorkedPerWeek(e.target.value)}
                   placeholder="e.g. 36"
+                  className="border-white/20 bg-white/10 text-white placeholder:text-white/40"
                 />
               </div>
-              <div className="items-center">
+              <div className="flex flex-1 flex-col justify-end space-y-2">
                 <Label
-                  id="hide-pay-label"
+                  id={`hide-pay-label-${formKey}`}
                   aria-label="Hide pay"
-                  htmlFor="hide-pay"
+                  htmlFor={`hide-pay-${formKey}`}
+                  className="text-white/80"
                 >
                   Hide pay
                 </Label>
-                <Switch
-                  id="hide-pay"
-                  aria-labelledby="hide-pay-label"
-                  className="mt-2 ml-0 text-right"
-                  checked={isPayHidden}
-                  onCheckedChange={() => setIsPayHidden(!isPayHidden)}
-                />
+                <div className="flex items-center gap-3 rounded-lg border border-white/10 bg-white/5 px-3 py-2">
+                  <Switch
+                    id={`hide-pay-${formKey}`}
+                    aria-labelledby={`hide-pay-label-${formKey}`}
+                    className="data-[state=checked]:bg-emerald-400"
+                    checked={isPayHidden}
+                    onCheckedChange={() => setIsPayHidden(!isPayHidden)}
+                  />
+                  <span className="text-sm text-white/70">
+                    {isPayHidden ? 'Hidden for others' : 'Visible to everyone'}
+                  </span>
+                </div>
               </div>
             </div>
-            <Separator />
-          </div>
-        </form>
-      </CardContent>
-      <CardFooter className="flex justify-between">
-        <Button variant="outline" onClick={() => removeForm(formKey)}>
-          Cancel
-        </Button>
-        <Button onClick={handleAddUser}>Add</Button>
-      </CardFooter>
-    </Card>
+          </form>
+        </CardContent>
+        <CardFooter className="flex items-center justify-between gap-3">
+          <MotionButton
+            variant="outline"
+            onClick={() => removeForm(formKey)}
+            whileHover={{ scale: 1.05 }}
+            whileTap={{ scale: 0.96 }}
+            className="border-white/30 text-white hover:bg-white/10"
+          >
+            Cancel
+          </MotionButton>
+          <MotionButton
+            onClick={handleAddUser}
+            disabled={!isValid}
+            whileHover={{ scale: isValid ? 1.05 : 1 }}
+            whileTap={{ scale: isValid ? 0.96 : 1 }}
+            className="bg-emerald-400 text-slate-900 hover:bg-emerald-300 disabled:bg-white/30 disabled:text-white/60"
+          >
+            Add attendee
+          </MotionButton>
+        </CardFooter>
+      </Card>
+    </motion.div>
   );
 };
 

--- a/src/components/user-cards/user-view-card.tsx
+++ b/src/components/user-cards/user-view-card.tsx
@@ -1,14 +1,28 @@
 'use client';
 
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import SlotCounter from 'react-slot-counter';
+import { motion } from 'framer-motion';
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card';
 import { Label } from '@/components/ui/label';
+import { Button } from '@/components/ui/button';
+import { Pencil } from 'lucide-react';
 import { User } from '@/interfaces/user';
 import { salaryPerSecond } from '@/lib/calcuate-salary';
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { useStopwatch } from '@/components/useStopwatch';
-import SlotCounter from 'react-slot-counter';
-import { Button } from '../ui/button';
-import { Pencil } from 'lucide-react';
+
+const MotionButton = motion(Button);
+
+const cardVariants = {
+  initial: { opacity: 0, y: 24, scale: 0.96 },
+  animate: { opacity: 1, y: 0, scale: 1, transition: { duration: 0.35 } },
+  exit: { opacity: 0, y: -16, scale: 0.95, transition: { duration: 0.2 } },
+};
 
 const UserViewCard = ({
   user,
@@ -20,47 +34,78 @@ const UserViewCard = ({
   const { name, amount, payVariant, hoursWorkedPerWeek, isPayHidden } = user;
   const { timeElapsed, isRunning } = useStopwatch();
   const [moneyWasted, setMoneyWasted] = useState<number>(0);
-  const payPerSecond = salaryPerSecond(amount, payVariant, hoursWorkedPerWeek);
+  const payPerSecond = useMemo(
+    () => salaryPerSecond(amount, payVariant, hoursWorkedPerWeek),
+    [amount, hoursWorkedPerWeek, payVariant],
+  );
 
   useEffect(() => {
     setMoneyWasted((timeElapsed / 1000) * payPerSecond);
   }, [payPerSecond, timeElapsed]);
 
   return (
-    <Card className="w-[350px] my-5">
-      <div className="flex justify-between">
-        <CardHeader>
-          <CardTitle>{name}</CardTitle>
-        </CardHeader>
-        <Button
-          className={`shrink-0 mt-2 mr-2 ${isRunning ? 'hidden' : ''}`}
-          aria-label="edit user information"
-          variant={'ghost'}
-          disabled={isRunning}
-          size={'icon'}
-          onClick={() => editUser(user)}
-        >
-          <Pencil className="h-4 w-4" />
-        </Button>
-      </div>
+    <motion.div
+      layout
+      variants={cardVariants}
+      initial="initial"
+      animate="animate"
+      exit="exit"
+      whileHover={{ translateY: -6 }}
+    >
+      <Card className="my-5 w-full border-white/10 bg-white/5 text-white shadow-xl backdrop-blur">
+        <div className="flex items-start justify-between">
+          <CardHeader>
+            <CardTitle className="text-xl font-semibold text-white">
+              {name}
+            </CardTitle>
+            <p className="text-sm text-white/60">
+              {isPayHidden ? 'Compensation hidden for participants' : 'Compensation visible to everyone'}
+            </p>
+          </CardHeader>
+          <MotionButton
+            className={`mt-4 mr-4 shrink-0 text-white hover:bg-white/10 ${isRunning ? 'pointer-events-none opacity-50' : ''}`}
+            aria-label="edit user information"
+            variant={'ghost'}
+            disabled={isRunning}
+            size={'icon'}
+            whileHover={{ rotate: -3 }}
+            whileTap={{ scale: 0.9 }}
+            onClick={() => editUser(user)}
+          >
+            <Pencil className="h-4 w-4" />
+          </MotionButton>
+        </div>
 
-      <CardContent>
-        <form>
-          <div className="grid w-full items-center gap-4">
-            <div className="flex flex-col space-y-1.5">
-              <Label htmlFor="pay">Your money</Label>
-              <h2 id="pay" className="text-xl">
-                {!isPayHidden ? `$${amount} ${payVariant}` : 'Hidden'}
-              </h2>
-              <div>
-                <span>Cost: $</span>
-                <SlotCounter value={moneyWasted.toFixed(2)} />
-              </div>
+        <CardContent className="space-y-6">
+          <div className="space-y-2">
+            <Label htmlFor="pay" className="text-white/70">
+              Compensation
+            </Label>
+            <h2 id="pay" className="text-2xl font-medium text-white">
+              {!isPayHidden ? `$${amount} ${payVariant}` : 'Hidden'}
+            </h2>
+            <p className="text-sm text-white/60">
+              Based on {hoursWorkedPerWeek} hrs/week •{' '}
+              {payPerSecond.toLocaleString(undefined, {
+                style: 'currency',
+                currency: 'USD',
+                minimumFractionDigits: 4,
+              })}{' '}
+              per second
+            </p>
+          </div>
+          <div className="rounded-2xl border border-emerald-400/40 bg-emerald-400/10 p-4 text-emerald-100">
+            <span className="text-sm uppercase tracking-[0.2em] text-emerald-200">
+              Cost so far
+            </span>
+            <div className="mt-1 flex items-baseline gap-2 text-3xl font-semibold">
+              <span>$</span>
+              <SlotCounter value={moneyWasted.toFixed(2)} />
             </div>
           </div>
-        </form>
-      </CardContent>
-    </Card>
+        </CardContent>
+      </Card>
+    </motion.div>
   );
 };
 

--- a/src/lib/room-service.ts
+++ b/src/lib/room-service.ts
@@ -1,0 +1,93 @@
+export type JoinRoomResult =
+  | {
+      status: 'joined';
+      roomCode: string;
+      roomName?: string;
+    }
+  | {
+      status: 'password_required';
+      roomCode: string;
+      message: string;
+    }
+  | {
+      status: 'invalid_password';
+      roomCode: string;
+      message: string;
+    }
+  | {
+      status: 'not_found';
+      roomCode: string;
+      message: string;
+    };
+
+interface MockRoomRecord {
+  name: string;
+  password?: string | null;
+}
+
+const MOCK_ROOMS: Record<string, MockRoomRecord> = {
+  ALPHA123: {
+    name: 'Product Strategy Sync',
+  },
+  BETA456: {
+    name: 'Design Review',
+    password: 'sketch',
+  },
+  GAMMA789: {
+    name: 'Finance Check-in',
+    password: 'numbers',
+  },
+};
+
+const wait = (duration = 700) =>
+  new Promise((resolve) => setTimeout(resolve, duration));
+
+export const joinRoom = async (
+  roomCode: string,
+  password?: string,
+): Promise<JoinRoomResult> => {
+  await wait();
+  const normalizedCode = roomCode.trim().toUpperCase();
+
+  if (!normalizedCode) {
+    return {
+      status: 'not_found',
+      roomCode: normalizedCode,
+      message: 'Enter a room code to continue.',
+    };
+  }
+
+  const room = MOCK_ROOMS[normalizedCode];
+
+  if (!room) {
+    return {
+      status: 'not_found',
+      roomCode: normalizedCode,
+      message: 'We could not find a room with that code.',
+    };
+  }
+
+  if (room.password) {
+    if (!password) {
+      return {
+        status: 'password_required',
+        roomCode: normalizedCode,
+        message: 'This room is protected. Enter the password to join.',
+      };
+    }
+
+    if (password !== room.password) {
+      return {
+        status: 'invalid_password',
+        roomCode: normalizedCode,
+        message: 'That password was not correct. Try again.',
+      };
+    }
+  }
+
+  return {
+    status: 'joined',
+    roomCode: normalizedCode,
+    roomName: room.name,
+  };
+};


### PR DESCRIPTION
## Summary
- introduce a cinematic home screen with feature highlights and smooth transitions before entering the meeting dashboard
- add an interactive room join workflow with password prompts and feedback backed by a mock room service
- refresh the meeting dashboard, user cards, stopwatch, and cost counter with motion-driven layouts and dark glassmorphism styling
- wire the new views together inside the main page and extend global styling plus dependencies for animation support

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68caff06605c8325a8ead552bd4ecf29