### PR TITLE
Add animated home screen and room join flow

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@radix-ui/react-switch": "^1.0.3",
         "class-variance-authority": "^0.7.0",
         "clsx": "^2.1.0",
+        "framer-motion": "^12.23.13",
         "lucide-react": "^0.367.0",
         "luxon": "^3.4.4",
         "next": "^14.2.21",
@@ -3458,6 +3459,33 @@
         "url": "https://github.com/sponsors/rawify"
       }
     },
+    "node_modules/framer-motion": {
+      "version": "12.23.13",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.23.13.tgz",
+      "integrity": "sha512-OMF57Xh0fuTXfJQPtCieYGeU9Fam4SxqPLVz78YI7ATRFrfz8SARtqr1+qv56cX45kPFcIEfkUorVfxlOsjcUg==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-dom": "^12.23.12",
+        "motion-utils": "^12.23.6",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -4639,6 +4667,21 @@
       "engines": {
         "node": ">=16 || 14 >=14.17"
       }
+    },
+    "node_modules/motion-dom": {
+      "version": "12.23.12",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.23.12.tgz",
+      "integrity": "sha512-RcR4fvMCTESQBD/uKQe49D5RUeDOokkGRmz4ceaJKDBgHYtZtntC/s2vLvY38gqGaytinij/yi3hMcWVcEF5Kw==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-utils": "^12.23.6"
+      }
+    },
+    "node_modules/motion-utils": {
+      "version": "12.23.6",
+      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.23.6.tgz",
+      "integrity": "sha512-eAWoPgr4eFEOFfg2WjIsMoqJTW6Z8MTUCgn/GZ3VRpClWBdnbjryiA3ZSNLyxCTmCQx4RmYX6jX1iWHbenUPNQ==",
+      "license": "MIT"
     },
     "node_modules/ms": {
       "version": "2.1.3",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
     "url": "https://github.com/whaagmans/meeting-costs-calculator/issues"
   },
   "homepage": "https://github.com/whaagmans/meeting-costs-calculator#readme",
-
   "scripts": {
     "dev": "next dev",
     "build": "next build",
@@ -30,6 +29,7 @@
     "@radix-ui/react-switch": "^1.0.3",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.0",
+    "framer-motion": "^12.23.13",
     "lucide-react": "^0.367.0",
     "luxon": "^3.4.4",
     "next": "^14.2.21",

--- a/src/app/api/rooms/join/route.ts
+++ b/src/app/api/rooms/join/route.ts
@@ -1,0 +1,72 @@
+const rooms = new Map(
+  Object.entries({
+    OPEN123: { requiresPassword: false },
+    SYNC456: { requiresPassword: true, password: 'sync' },
+    DESIGN789: { requiresPassword: true, password: 'design' },
+  }),
+);
+
+const normalizeCode = (code: string) => code.trim().toUpperCase();
+
+export async function POST(request: Request) {
+  const { roomCode, password } = await request.json();
+
+  if (!roomCode || typeof roomCode !== 'string') {
+    return Response.json(
+      { status: 'invalid', message: 'Please provide a room code.' },
+      { status: 400 },
+    );
+  }
+
+  const normalizedCode = normalizeCode(roomCode);
+  const room = rooms.get(normalizedCode);
+
+  if (!room) {
+    return Response.json(
+      { status: 'not-found', message: 'Room not found.' },
+      { status: 404 },
+    );
+  }
+
+  if (!room.requiresPassword) {
+    return Response.json(
+      {
+        status: 'success',
+        message: 'Joined room successfully.',
+        roomCode: normalizedCode,
+      },
+      { status: 200 },
+    );
+  }
+
+  if (!password) {
+    return Response.json(
+      {
+        status: 'requires-password',
+        message: 'This room is protected by a password.',
+        roomCode: normalizedCode,
+      },
+      { status: 200 },
+    );
+  }
+
+  if (password !== room.password) {
+    return Response.json(
+      {
+        status: 'invalid-password',
+        message: 'Incorrect password supplied.',
+        roomCode: normalizedCode,
+      },
+      { status: 401 },
+    );
+  }
+
+  return Response.json(
+    {
+      status: 'success',
+      message: 'Password accepted. Welcome in!',
+      roomCode: normalizedCode,
+    },
+    { status: 200 },
+  );
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,3 +1,58 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+@layer base {
+  :root {
+    --background: 210 40% 98%;
+    --foreground: 222.2 47.4% 11.2%;
+    --card: 0 0% 100%;
+    --card-foreground: 222.2 47.4% 11.2%;
+    --popover: 0 0% 100%;
+    --popover-foreground: 222.2 47.4% 11.2%;
+    --primary: 158 64% 45%;
+    --primary-foreground: 144 70% 96%;
+    --secondary: 210 40% 96%;
+    --secondary-foreground: 222.2 47.4% 11.2%;
+    --muted: 210 40% 96.1%;
+    --muted-foreground: 215.4 16.3% 46.9%;
+    --accent: 210 40% 96.1%;
+    --accent-foreground: 222.2 47.4% 11.2%;
+    --destructive: 0 84.2% 60.2%;
+    --destructive-foreground: 0 0% 98%;
+    --border: 210 40% 90%;
+    --input: 210 40% 90%;
+    --ring: 158 64% 45%;
+    --radius: 1rem;
+  }
+
+  .dark {
+    --background: 222.2 84% 4.9%;
+    --foreground: 210 40% 98%;
+    --card: 222.2 84% 4.9%;
+    --card-foreground: 210 40% 98%;
+    --popover: 222.2 84% 4.9%;
+    --popover-foreground: 210 40% 98%;
+    --primary: 158 64% 45%;
+    --primary-foreground: 144 70% 96%;
+    --secondary: 217.2 32.6% 17.5%;
+    --secondary-foreground: 210 40% 98%;
+    --muted: 217.2 32.6% 17.5%;
+    --muted-foreground: 210 40% 78%;
+    --accent: 217.2 32.6% 17.5%;
+    --accent-foreground: 210 40% 98%;
+    --destructive: 0 63% 31%;
+    --destructive-foreground: 210 40% 98%;
+    --border: 217.2 32.6% 17.5%;
+    --input: 217.2 32.6% 17.5%;
+    --ring: 158 64% 45%;
+  }
+
+  body {
+    @apply bg-background text-foreground;
+  }
+
+  ::selection {
+    @apply bg-primary/30 text-primary-foreground;
+  }
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,13 +1,67 @@
 'use client';
 
+import { useCallback, useState } from 'react';
+import { AnimatePresence, motion } from 'framer-motion';
 import MeetingDashboard from '@/components/meeting-dashboard';
 import { StopwatchProvider } from '@/components/useStopwatch';
+import HomeScreen from '@/components/home-screen';
+
+type AppView = 'home' | 'dashboard';
+
+const viewVariants = {
+  initial: { opacity: 0, y: 24 },
+  animate: { opacity: 1, y: 0 },
+  exit: { opacity: 0, y: -24 },
+};
 
 export default function Home() {
+  const [view, setView] = useState<AppView>('home');
+  const [activeRoom, setActiveRoom] = useState<string | null>(null);
+
+  const goToDashboard = useCallback(() => {
+    setView('dashboard');
+  }, []);
+
+  const handleJoinRoom = useCallback((roomCode: string) => {
+    setActiveRoom(roomCode);
+    setView('dashboard');
+  }, []);
+
+  const handleExit = useCallback(() => {
+    setActiveRoom(null);
+    setView('home');
+  }, []);
+
   return (
-    <main className="relative">
+    <main className="relative min-h-screen overflow-hidden">
+      <div className="pointer-events-none absolute inset-0 -z-20 bg-[radial-gradient(circle_at_top,_rgba(16,185,129,0.2),transparent_55%)]" />
+      <div className="pointer-events-none absolute inset-0 -z-10 bg-[radial-gradient(circle_at_bottom,_rgba(59,130,246,0.15),transparent_60%)]" />
       <StopwatchProvider>
-        <MeetingDashboard />
+        <AnimatePresence mode="wait">
+          {view === 'home' ? (
+            <motion.div
+              key="home"
+              variants={viewVariants}
+              initial="initial"
+              animate="animate"
+              exit="exit"
+              transition={{ duration: 0.35, ease: 'easeOut' }}
+            >
+              <HomeScreen onStartMeeting={goToDashboard} onJoinRoom={handleJoinRoom} />
+            </motion.div>
+          ) : (
+            <motion.div
+              key="dashboard"
+              variants={viewVariants}
+              initial="initial"
+              animate="animate"
+              exit="exit"
+              transition={{ duration: 0.35, ease: 'easeOut' }}
+            >
+              <MeetingDashboard onExit={handleExit} roomCode={activeRoom} />
+            </motion.div>
+          )}
+        </AnimatePresence>
       </StopwatchProvider>
     </main>
   );

--- a/src/components/home-screen.tsx
+++ b/src/components/home-screen.tsx
@@ -1,0 +1,95 @@
+'use client';
+
+import { motion } from 'framer-motion';
+import { Button } from './ui/button';
+import RoomJoinForm from './room-join-form';
+
+interface HomeScreenProps {
+  onStartMeeting: () => void;
+  onJoinRoom: (roomCode: string) => void;
+}
+
+const featureCards = [
+  {
+    title: 'Track meeting burn rate',
+    description:
+      'See the running cost of your meeting in real time and keep everyone mindful of their time.',
+  },
+  {
+    title: 'Manage attendees effortlessly',
+    description:
+      'Add and edit participants with their pay details and work schedules to get accurate numbers.',
+  },
+  {
+    title: 'Collaborate in shared rooms',
+    description:
+      'Join protected rooms by code so the whole team can stay aligned on meeting costs.',
+  },
+];
+
+const HomeScreen = ({ onStartMeeting, onJoinRoom }: HomeScreenProps) => {
+  return (
+    <div className="flex flex-col items-center px-6 py-16 lg:py-24 gap-12 text-center">
+      <motion.div
+        initial={{ opacity: 0, y: 20 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.6, ease: 'easeOut' }}
+        className="max-w-3xl space-y-6"
+      >
+        <span className="inline-flex items-center rounded-full border border-primary/40 bg-primary/10 px-4 py-1 text-sm font-semibold uppercase tracking-wider text-primary shadow-sm">
+          Stay on top of meeting costs
+        </span>
+        <h1 className="text-4xl font-bold tracking-tight sm:text-5xl lg:text-6xl">
+          Every minute counts. Make your meetings intentional.
+        </h1>
+        <p className="text-lg text-muted-foreground">
+          Meeting Costs Calculator helps you understand the true cost of bringing people together. Plan smarter, stay on time, and make space for focused work.
+        </p>
+        <div className="flex flex-col items-center justify-center gap-4 sm:flex-row">
+          <Button size="lg" onClick={onStartMeeting} className="px-8 text-base">
+            Launch the calculator
+          </Button>
+          <Button
+            size="lg"
+            variant="outline"
+            onClick={onStartMeeting}
+            className="px-8 text-base"
+          >
+            Create a new room
+          </Button>
+        </div>
+      </motion.div>
+
+      <motion.div
+        initial={{ opacity: 0, y: 20 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.6, ease: 'easeOut', delay: 0.1 }}
+        className="grid w-full max-w-5xl gap-6 md:grid-cols-3"
+      >
+        {featureCards.map((feature, index) => (
+          <motion.div
+            key={feature.title}
+            initial={{ opacity: 0, y: 24 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.5, ease: 'easeOut', delay: 0.1 * index }}
+            className="rounded-2xl border border-primary/10 bg-background/70 p-6 text-left shadow-lg shadow-primary/10 backdrop-blur"
+          >
+            <h3 className="text-xl font-semibold">{feature.title}</h3>
+            <p className="mt-3 text-sm text-muted-foreground">{feature.description}</p>
+          </motion.div>
+        ))}
+      </motion.div>
+
+      <motion.div
+        initial={{ opacity: 0, y: 20 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.6, ease: 'easeOut', delay: 0.2 }}
+        className="w-full flex justify-center"
+      >
+        <RoomJoinForm onEnterRoom={onJoinRoom} />
+      </motion.div>
+    </div>
+  );
+};
+
+export default HomeScreen;

--- a/src/components/meeting-cost-counter.tsx
+++ b/src/components/meeting-cost-counter.tsx
@@ -29,7 +29,7 @@ const MeetingCostCounter = ({ users }: { users: User[] }) => {
   }, [timeElapsed, totalPayRatePerSecond]);
 
   return (
-    <div className="text-4xl py-4 px-6 flex items-center">
+    <div className="inline-flex items-center gap-2 rounded-full border border-primary/20 bg-primary/10 px-6 py-3 text-3xl font-semibold text-primary shadow-inner shadow-primary/20">
       <span className="align-middle">$</span>
       <SlotCounter value={wastedAmount.toFixed(2)} />
     </div>

--- a/src/components/meeting-dashboard.tsx
+++ b/src/components/meeting-dashboard.tsx
@@ -10,8 +10,16 @@ import { Button } from './ui/button';
 import UserInputCard from './user-cards/user-input-card';
 import UserViewCard from './user-cards/user-view-card';
 import { useStopwatch } from './useStopwatch';
+import { motion, AnimatePresence } from 'framer-motion';
+import { ChevronLeft, RefreshCcw } from 'lucide-react';
+import { cn } from '@/lib/utils';
 
-const MeetingDashboard = () => {
+interface MeetingDashboardProps {
+  onExit?: () => void;
+  roomCode?: string | null;
+}
+
+const MeetingDashboard = ({ onExit, roomCode }: MeetingDashboardProps) => {
   const { pause, start, reset, isRunning, timeElapsed } = useStopwatch();
   const [users, setUsers] = useState<Array<User>>([]);
   const [forms, setForms] = useState<Form[]>([{ key: crypto.randomUUID() }]);
@@ -63,6 +71,7 @@ const MeetingDashboard = () => {
         size={'lg'}
         variant={!hasMeetingStarted ? 'default' : 'destructive'}
         onClick={toggleEditMode}
+        className="min-w-[120px] transition-transform hover:-translate-y-0.5"
       >
         {text}
       </Button>
@@ -70,47 +79,117 @@ const MeetingDashboard = () => {
   };
 
   return (
-    <div>
-      {(hasMeetingStarted || timeElapsed > 0) && (
-        <div>
-          <div className="absolute inset-x-0 flex justify-center mt-10">
-            <Stopwatch />
-          </div>
-          <div className="absolute inset-x-0 top-1/3 flex justify-center">
-            <MeetingCostCounter users={users} />
-          </div>
-        </div>
-      )}
-      <div className="flex min-h-screen items-center align-middle flex-wrap space-x-5 p-6">
-        {forms.map((form) => (
-          <UserInputCard
-            key={form.key}
-            formKey={form.key}
-            addUser={addUser}
-            removeForm={removeForm}
-            user={form.user}
-          />
-        ))}
-        {users.map((user) => (
-          <div key={user.id}>
-            <UserViewCard user={user} editUser={editUser} />
-          </div>
-        ))}
-      </div>
-      <div className="fixed bottom-12 inset-x-0 space-x-6 flex justify-center">
-        {users.length > 0 && renderStopStartMeetingButton()}
-        {!hasMeetingStarted && (
-          <>
+    <div className="relative min-h-screen">
+      <div className="sticky top-0 flex items-center justify-between px-6 py-4 backdrop-blur-lg bg-background/70 border-b border-primary/10 z-20">
+        <div className="flex items-center gap-2">
+          {onExit && (
             <Button
-              className={timeElapsed > 0 ? '' : 'hidden'}
+              variant="ghost"
+              size="sm"
+              onClick={onExit}
+              className="transition-transform hover:-translate-x-1"
+            >
+              <ChevronLeft className="mr-2 h-4 w-4" />
+              Home
+            </Button>
+          )}
+          <span className="text-sm uppercase tracking-[0.25em] text-primary/70 hidden sm:inline">
+            Live meeting tracker
+          </span>
+        </div>
+        <div className="flex items-center gap-3">
+          {roomCode && (
+            <motion.span
+              initial={{ opacity: 0, y: -6 }}
+              animate={{ opacity: 1, y: 0 }}
+              className="rounded-full border border-primary/20 bg-primary/10 px-3 py-1 text-xs font-semibold uppercase tracking-widest text-primary"
+            >
+              Room {roomCode}
+            </motion.span>
+          )}
+          <motion.div
+            initial={{ opacity: 0, y: -10 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.4, ease: 'easeOut' }}
+          >
+            <Stopwatch />
+          </motion.div>
+          <motion.div
+            initial={{ opacity: 0, y: -12 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.4, ease: 'easeOut', delay: 0.1 }}
+          >
+            <MeetingCostCounter users={users} />
+          </motion.div>
+        </div>
+      </div>
+
+      <div className="flex flex-wrap items-start justify-center gap-6 px-6 pb-36 pt-10">
+        <AnimatePresence>
+          {forms.map((form) => (
+            <motion.div
+              key={form.key}
+              layout
+              initial={{ opacity: 0, scale: 0.95, y: 12 }}
+              animate={{ opacity: 1, scale: 1, y: 0 }}
+              exit={{ opacity: 0, scale: 0.9, y: -12 }}
+              transition={{ duration: 0.25 }}
+            >
+              <UserInputCard
+                formKey={form.key}
+                addUser={addUser}
+                removeForm={removeForm}
+                user={form.user}
+              />
+            </motion.div>
+          ))}
+        </AnimatePresence>
+
+        <AnimatePresence>
+          {users.map((user) => (
+            <motion.div
+              key={user.id}
+              layout
+              initial={{ opacity: 0, scale: 0.95, y: 12 }}
+              animate={{ opacity: 1, scale: 1, y: 0 }}
+              exit={{ opacity: 0, scale: 0.9, y: -12 }}
+              transition={{ duration: 0.25 }}
+            >
+              <UserViewCard user={user} editUser={editUser} />
+            </motion.div>
+          ))}
+        </AnimatePresence>
+      </div>
+
+      <div className="fixed bottom-8 inset-x-0 flex flex-wrap items-center justify-center gap-4 px-6">
+        {users.length > 0 && (
+          <motion.div
+            initial={{ opacity: 0, y: 12 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.3 }}
+          >
+            {renderStopStartMeetingButton()}
+          </motion.div>
+        )}
+
+        {!hasMeetingStarted && (
+          <motion.div
+            initial={{ opacity: 0, y: 12 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.3, delay: 0.05 }}
+            className="flex flex-wrap justify-center gap-3"
+          >
+            <Button
+              className={cn('transition-all', timeElapsed > 0 ? 'opacity-100' : 'hidden')}
               variant={'destructive'}
               size={'lg'}
               onClick={reset}
             >
+              <RefreshCcw className="mr-2 h-4 w-4" />
               Reset
             </Button>
             <Button
-              className={hasMeetingStarted ? 'hidden' : ''}
+              className={hasMeetingStarted ? 'hidden' : 'transition-transform hover:-translate-y-0.5'}
               size={'lg'}
               variant={'success'}
               disabled={hasMeetingStarted}
@@ -119,7 +198,7 @@ const MeetingDashboard = () => {
               <UserPlus className="mr-2 h-5 w-5" />
               Add user
             </Button>
-          </>
+          </motion.div>
         )}
       </div>
     </div>

--- a/src/components/room-join-form.tsx
+++ b/src/components/room-join-form.tsx
@@ -1,0 +1,190 @@
+'use client';
+
+import { FormEvent, useState } from 'react';
+import { motion, AnimatePresence } from 'framer-motion';
+import { Input } from './ui/input';
+import { Button } from './ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from './ui/card';
+
+interface RoomJoinFormProps {
+  onEnterRoom?: (roomCode: string) => void;
+}
+
+type StepState = 'idle' | 'requires-password' | 'success';
+
+interface ApiResponse {
+  status: 'invalid' | 'not-found' | 'requires-password' | 'invalid-password' | 'success';
+  message: string;
+  roomCode?: string;
+}
+
+const feedbackVariants = {
+  initial: { opacity: 0, y: 10 },
+  animate: { opacity: 1, y: 0 },
+  exit: { opacity: 0, y: -10 },
+};
+
+const RoomJoinForm = ({ onEnterRoom }: RoomJoinFormProps) => {
+  const [step, setStep] = useState<StepState>('idle');
+  const [roomCode, setRoomCode] = useState('');
+  const [password, setPassword] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [feedback, setFeedback] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const resetFeedback = () => {
+    setFeedback(null);
+    setError(null);
+  };
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (loading) return;
+    resetFeedback();
+    setLoading(true);
+
+    try {
+      const response = await fetch('/api/rooms/join', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          roomCode,
+          password: step === 'requires-password' ? password : undefined,
+        }),
+      });
+
+      const data = (await response.json()) as ApiResponse;
+
+      if (data.status === 'requires-password') {
+        setStep('requires-password');
+        setFeedback(data.message);
+      } else if (data.status === 'invalid-password') {
+        setStep('requires-password');
+        setPassword('');
+        setError('That password was incorrect. Try again.');
+      } else if (data.status === 'not-found') {
+        setStep('idle');
+        setError('We could not find that room. Double-check the code.');
+      } else if (data.status === 'invalid') {
+        setStep('idle');
+        setError('Please enter a valid room code to continue.');
+      } else if (data.status === 'success') {
+        setStep('success');
+        setFeedback('Success! Redirecting you to the room...');
+        setTimeout(() => {
+          onEnterRoom?.(data.roomCode ?? roomCode);
+          setLoading(false);
+        }, 600);
+        return;
+      }
+    } catch (err) {
+      setError('Something went wrong while joining. Please try again.');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const isPasswordStep = step === 'requires-password';
+
+  return (
+    <Card className="w-full max-w-xl backdrop-blur border-primary/20 bg-background/70">
+      <CardHeader>
+        <CardTitle className="text-2xl font-semibold tracking-tight">Join a meeting room</CardTitle>
+        <CardDescription>
+          Enter the shared room code below. If the room is protected, we&apos;ll ask for the password.
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div className="grid gap-2">
+            <label htmlFor="room-code" className="text-sm font-medium">
+              Room code
+            </label>
+            <Input
+              id="room-code"
+              value={roomCode}
+              onChange={(event) => setRoomCode(event.target.value.toUpperCase())}
+              placeholder="e.g. OPEN123"
+              maxLength={8}
+              disabled={loading || step === 'success'}
+              className="uppercase tracking-wider text-lg"
+            />
+          </div>
+
+          <AnimatePresence mode="wait">
+            {isPasswordStep && (
+              <motion.div
+                key="password"
+                initial={{ opacity: 0, y: 12 }}
+                animate={{ opacity: 1, y: 0 }}
+                exit={{ opacity: 0, y: -12 }}
+                transition={{ duration: 0.25, ease: 'easeOut' }}
+                className="grid gap-2"
+              >
+                <label htmlFor="password" className="text-sm font-medium">
+                  Room password
+                </label>
+                <Input
+                  id="password"
+                  type="password"
+                  value={password}
+                  onChange={(event) => setPassword(event.target.value)}
+                  placeholder="Enter the secret"
+                  disabled={loading}
+                />
+              </motion.div>
+            )}
+          </AnimatePresence>
+
+          <Button
+            type="submit"
+            size="lg"
+            className="w-full transition-transform hover:translate-y-[-2px]"
+            disabled={loading || !roomCode.trim() || step === 'success'}
+          >
+            {loading
+              ? 'Checking room...'
+              : isPasswordStep
+                ? 'Submit password'
+                : 'Join room'}
+          </Button>
+        </form>
+
+        <div className="min-h-[48px] mt-4">
+          <AnimatePresence mode="wait">
+            {feedback && !error && (
+              <motion.p
+                key="feedback"
+                variants={feedbackVariants}
+                initial="initial"
+                animate="animate"
+                exit="exit"
+                transition={{ duration: 0.25 }}
+                className="text-sm text-emerald-500"
+              >
+                {feedback}
+              </motion.p>
+            )}
+            {error && (
+              <motion.p
+                key="error"
+                variants={feedbackVariants}
+                initial="initial"
+                animate="animate"
+                exit="exit"
+                transition={{ duration: 0.25 }}
+                className="text-sm text-destructive"
+              >
+                {error}
+              </motion.p>
+            )}
+          </AnimatePresence>
+        </div>
+      </CardContent>
+    </Card>
+  );
+};
+
+export default RoomJoinForm;

--- a/src/components/stopwatch.tsx
+++ b/src/components/stopwatch.tsx
@@ -2,12 +2,18 @@
 
 import { Duration } from 'luxon';
 import { useStopwatch } from './useStopwatch';
+import { motion } from 'framer-motion';
 
 export const Stopwatch = () => {
   const { timeElapsed } = useStopwatch();
   return (
-    <div className="items-center text-4xl font-bold">
+    <motion.div
+      initial={{ opacity: 0, y: -8 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.3 }}
+      className="inline-flex items-center rounded-full border border-primary/20 bg-background/80 px-5 py-2 text-2xl font-semibold tracking-widest"
+    >
       {Duration.fromMillis(timeElapsed).toFormat('hh:mm:ss')}
-    </div>
+    </motion.div>
   );
 };

--- a/src/components/user-cards/user-input-card.tsx
+++ b/src/components/user-cards/user-input-card.tsx
@@ -25,6 +25,7 @@ import { useState } from 'react';
 import { Switch } from '../ui/switch';
 import { Separator } from '../ui/separator';
 import { User } from '@/interfaces/user';
+import { motion } from 'framer-motion';
 
 const UserInputCard = ({
   formKey,
@@ -63,13 +64,23 @@ const UserInputCard = ({
     removeForm(formKey);
   };
 
+  const isAddDisabled =
+    !name.trim() || Number(amount) <= 0 || Number(hoursWorkedPerWeek) <= 0;
+
   return (
-    <Card className="w-[350px] my-5">
-      <div className="flex justify-around">
-        <CardHeader>
-          <CardTitle>Add meeting attender</CardTitle>
-        </CardHeader>
-        <Button
+    <motion.div
+      layout
+      initial={{ opacity: 0, y: 16 }}
+      animate={{ opacity: 1, y: 0 }}
+      exit={{ opacity: 0, y: -16 }}
+      transition={{ duration: 0.25 }}
+    >
+      <Card className="w-[350px] my-5 shadow-lg shadow-primary/10 transition-all hover:-translate-y-1 hover:shadow-primary/20">
+        <div className="flex justify-around">
+          <CardHeader>
+            <CardTitle>Add meeting attender</CardTitle>
+          </CardHeader>
+          <Button
           onClick={() => removeForm(formKey)}
           className="shrink-0 mt-2 mr-2"
           aria-label="Remove form"
@@ -167,12 +178,23 @@ const UserInputCard = ({
         </form>
       </CardContent>
       <CardFooter className="flex justify-between">
-        <Button variant="outline" onClick={() => removeForm(formKey)}>
+        <Button
+          variant="outline"
+          onClick={() => removeForm(formKey)}
+          className="transition-transform hover:-translate-y-0.5"
+        >
           Cancel
         </Button>
-        <Button onClick={handleAddUser}>Add</Button>
+        <Button
+          onClick={handleAddUser}
+          disabled={isAddDisabled}
+          className="transition-transform hover:-translate-y-0.5 disabled:opacity-50"
+        >
+          Add
+        </Button>
       </CardFooter>
-    </Card>
+      </Card>
+    </motion.div>
   );
 };
 

--- a/src/components/user-cards/user-view-card.tsx
+++ b/src/components/user-cards/user-view-card.tsx
@@ -9,6 +9,7 @@ import { useStopwatch } from '@/components/useStopwatch';
 import SlotCounter from 'react-slot-counter';
 import { Button } from '../ui/button';
 import { Pencil } from 'lucide-react';
+import { motion } from 'framer-motion';
 
 const UserViewCard = ({
   user,
@@ -27,40 +28,48 @@ const UserViewCard = ({
   }, [payPerSecond, timeElapsed]);
 
   return (
-    <Card className="w-[350px] my-5">
-      <div className="flex justify-between">
-        <CardHeader>
-          <CardTitle>{name}</CardTitle>
-        </CardHeader>
-        <Button
-          className={`shrink-0 mt-2 mr-2 ${isRunning ? 'hidden' : ''}`}
-          aria-label="edit user information"
-          variant={'ghost'}
-          disabled={isRunning}
-          size={'icon'}
-          onClick={() => editUser(user)}
-        >
-          <Pencil className="h-4 w-4" />
-        </Button>
-      </div>
+    <motion.div
+      layout
+      initial={{ opacity: 0, y: 16 }}
+      animate={{ opacity: 1, y: 0 }}
+      exit={{ opacity: 0, y: -16 }}
+      transition={{ duration: 0.25 }}
+    >
+      <Card className="w-[350px] my-5 border-primary/20 bg-background/80 shadow-lg shadow-primary/10 backdrop-blur">
+        <div className="flex justify-between">
+          <CardHeader>
+            <CardTitle>{name}</CardTitle>
+          </CardHeader>
+          <Button
+            className={`shrink-0 mt-2 mr-2 ${isRunning ? 'hidden' : ''}`}
+            aria-label="edit user information"
+            variant={'ghost'}
+            disabled={isRunning}
+            size={'icon'}
+            onClick={() => editUser(user)}
+          >
+            <Pencil className="h-4 w-4" />
+          </Button>
+        </div>
 
-      <CardContent>
-        <form>
-          <div className="grid w-full items-center gap-4">
-            <div className="flex flex-col space-y-1.5">
-              <Label htmlFor="pay">Your money</Label>
-              <h2 id="pay" className="text-xl">
-                {!isPayHidden ? `$${amount} ${payVariant}` : 'Hidden'}
-              </h2>
-              <div>
-                <span>Cost: $</span>
-                <SlotCounter value={moneyWasted.toFixed(2)} />
+        <CardContent>
+          <form>
+            <div className="grid w-full items-center gap-4">
+              <div className="flex flex-col space-y-1.5">
+                <Label htmlFor="pay">Your money</Label>
+                <h2 id="pay" className="text-xl">
+                  {!isPayHidden ? `$${amount} ${payVariant}` : 'Hidden'}
+                </h2>
+                <div>
+                  <span>Cost: $</span>
+                  <SlotCounter value={moneyWasted.toFixed(2)} />
+                </div>
               </div>
             </div>
-          </div>
-        </form>
-      </CardContent>
-    </Card>
+          </form>
+        </CardContent>
+      </Card>
+    </motion.div>
   );
 };
 

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -19,6 +19,46 @@ const config = {
       },
     },
     extend: {
+      colors: {
+        border: 'hsl(var(--border))',
+        input: 'hsl(var(--input))',
+        ring: 'hsl(var(--ring))',
+        background: 'hsl(var(--background))',
+        foreground: 'hsl(var(--foreground))',
+        primary: {
+          DEFAULT: 'hsl(var(--primary))',
+          foreground: 'hsl(var(--primary-foreground))',
+        },
+        secondary: {
+          DEFAULT: 'hsl(var(--secondary))',
+          foreground: 'hsl(var(--secondary-foreground))',
+        },
+        destructive: {
+          DEFAULT: 'hsl(var(--destructive))',
+          foreground: 'hsl(var(--destructive-foreground))',
+        },
+        muted: {
+          DEFAULT: 'hsl(var(--muted))',
+          foreground: 'hsl(var(--muted-foreground))',
+        },
+        accent: {
+          DEFAULT: 'hsl(var(--accent))',
+          foreground: 'hsl(var(--accent-foreground))',
+        },
+        popover: {
+          DEFAULT: 'hsl(var(--popover))',
+          foreground: 'hsl(var(--popover-foreground))',
+        },
+        card: {
+          DEFAULT: 'hsl(var(--card))',
+          foreground: 'hsl(var(--card-foreground))',
+        },
+      },
+      borderRadius: {
+        lg: 'var(--radius)',
+        md: 'calc(var(--radius) - 2px)',
+        sm: 'calc(var(--radius) - 4px)',
+      },
       fontFamily: {
         sans: ['var(--font-sans)', ...fontFamily.sans],
       },


### PR DESCRIPTION
## Summary
- add an animated landing experience with feature highlights and an interactive room join form
- implement a mock join-room API that handles password-protected rooms and surface contextual feedback
- refresh the meeting dashboard styling with motion-driven transitions and shared design tokens
- fix the room join password input disabled state so the form type-checks and builds correctly

## Testing
- npm run lint
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68caff06605c8325a8ead552bd4ecf29